### PR TITLE
Integrate sonata admin classes and configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ matrix:
     - php: 5.5
       env: COMPOSER_FLAGS="--prefer-lowest" SYMFONY_VERSION=2.8.* SYMFONY_DEPRECATIONS_HELPER=weak
     - php: 7.0
-      env: DEPS=dev COMPOSER_FLAGS="--prefer-stable" SYMFONY_VERSION=3.0.*
+      env: DEPS=dev COMPOSER_FLAGS="--prefer-stable" SYMFONY_VERSION=3.0.* SYMFONY_DEPRECATIONS_HELPER=weak
     #- php: 7.0
     #  env: DEPS=dev COMPOSER_FLAGS="--prefer-stable" SYMFONY_VERSION=3.2.*
   fast_finish: true
@@ -37,7 +37,7 @@ before_install:
   - composer self-update
   - if [ "$DEPS" = "dev" ]; then perl -pi -e 's/^}$/,"minimum-stability":"dev"}/' composer.json; fi
   - if [ "$SYMFONY_VERSION" != "" ]; then composer require symfony/symfony:${SYMFONY_VERSION} --no-update; fi
-  
+
 install: composer update --prefer-dist $COMPOSER_FLAGS
 
 script: vendor/bin/simple-phpunit

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
         "symfony-cmf/routing-bundle": "^2.0",
         "symfony-cmf/seo-bundle": "^2.0",
         "symfony-cmf/menu-bundle": "^2.0",
+        "symfony-cmf/block-bundle": "^2.0",
         "doctrine/orm": "^2.4",
         "doctrine/phpcr-odm": "^2.0",
         "symfony/phpunit-bridge": "^3.2",

--- a/src/Admin/Block/AbstractBlockAdmin.php
+++ b/src/Admin/Block/AbstractBlockAdmin.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Symfony CMF package.
+ *
+ * (c) 2011-2016 Symfony CMF
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Cmf\Bundle\SonataAdminIntegrationBundle\Admin\Block;
+
+use Sonata\DoctrinePHPCRAdminBundle\Admin\Admin;
+
+/**
+ * @author Nicolas Bastien <nbastien@prestaconcept.net>
+ */
+abstract class AbstractBlockAdmin extends Admin
+{
+    /**
+     * @var string
+     */
+    protected $translationDomain = 'CmfBlockBundle';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getExportFormats()
+    {
+        return array();
+    }
+}

--- a/src/Admin/Block/ActionBlockAdmin.php
+++ b/src/Admin/Block/ActionBlockAdmin.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of the Symfony CMF package.
+ *
+ * (c) 2011-2016 Symfony CMF
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Cmf\Bundle\SonataAdminIntegrationBundle\Admin\Block;
+
+use Sonata\AdminBundle\Form\FormMapper;
+use Sonata\AdminBundle\Datagrid\DatagridMapper;
+use Sonata\AdminBundle\Datagrid\ListMapper;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Sonata\DoctrinePHPCRAdminBundle\Form\Type\TreeModelType;
+
+/**
+ * @author Lukas Kahwe Smith <smith@pooteeweet.org>
+ */
+class ActionBlockAdmin extends AbstractBlockAdmin
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function configureListFields(ListMapper $listMapper)
+    {
+        $listMapper
+            ->addIdentifier('id', 'text')
+            ->add('name', 'text')
+            ->add('actionName', 'text')
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configureFormFields(FormMapper $formMapper)
+    {
+        $formMapper
+            ->with('form.group_general')
+                ->add('parentDocument', TreeModelType::class, array('root_node' => $this->getRootPath(), 'choice_list' => array(), 'select_root_node' => true))
+                ->add('name', TextType::class)
+                ->add('actionName', TextType::class)
+            ->end()
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configureDatagridFilters(DatagridMapper $datagridMapper)
+    {
+        $datagridMapper
+            ->add('name', 'doctrine_phpcr_nodename')
+        ;
+    }
+}

--- a/src/Admin/Block/ContainerBlockAdmin.php
+++ b/src/Admin/Block/ContainerBlockAdmin.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the Symfony CMF package.
+ *
+ * (c) 2011-2016 Symfony CMF
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Cmf\Bundle\SonataAdminIntegrationBundle\Admin\Block;
+
+use Sonata\AdminBundle\Datagrid\DatagridMapper;
+use Sonata\AdminBundle\Datagrid\ListMapper;
+use Sonata\AdminBundle\Form\FormMapper;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Sonata\DoctrinePHPCRAdminBundle\Form\Type\TreeModelType;
+
+/**
+ * @author Lukas Kahwe Smith <smith@pooteeweet.org>
+ */
+class ContainerBlockAdmin extends AbstractBlockAdmin
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function configureListFields(ListMapper $listMapper)
+    {
+        $listMapper
+            ->addIdentifier('id', 'text')
+            ->add('name', 'text')
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configureFormFields(FormMapper $formMapper)
+    {
+        $formMapper
+            ->with('form.group_general')
+                ->add('parentDocument', TreeModelType::class, array('root_node' => $this->getRootPath(), 'choice_list' => array(), 'select_root_node' => true))
+                ->add('name', TextType::class)
+            ->end()
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configureDatagridFilters(DatagridMapper $datagridMapper)
+    {
+        $datagridMapper
+            ->add('name', 'doctrine_phpcr_nodename')
+        ;
+    }
+}

--- a/src/Admin/Block/Extension/BlockCacheExtension.php
+++ b/src/Admin/Block/Extension/BlockCacheExtension.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Symfony CMF package.
+ *
+ * (c) 2011-2016 Symfony CMF
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Cmf\Bundle\SonataAdminIntegrationBundle\Admin\Block\Extension;
+
+use Sonata\AdminBundle\Admin\AdminExtension;
+use Sonata\AdminBundle\Form\FormMapper;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+
+/**
+ * Provide cache form fields for block models.
+ *
+ * @author Sven Cludius <sven.cludius@valiton.com>
+ */
+class BlockCacheExtension extends AdminExtension
+{
+    /**
+     * Configure form fields.
+     *
+     * @param FormMapper $formMapper
+     */
+    public function configureFormFields(FormMapper $formMapper)
+    {
+        $formMapper
+            ->with('form.group_metadata', array('translation_domain' => 'CmfBlockBundle'))
+                ->add('ttl', TextType::class)
+            ->end()
+        ;
+    }
+}

--- a/src/Admin/Block/Imagine/ImagineBlockAdmin.php
+++ b/src/Admin/Block/Imagine/ImagineBlockAdmin.php
@@ -1,0 +1,80 @@
+<?php
+
+/*
+ * This file is part of the Symfony CMF package.
+ *
+ * (c) 2011-2016 Symfony CMF
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Cmf\Bundle\SonataAdminIntegrationBundle\Admin\Block\Imagine;
+
+use Symfony\Cmf\Bundle\SonataAdminIntegrationBundle\Admin\Block\AbstractBlockAdmin;
+use Sonata\AdminBundle\Form\FormMapper;
+use Sonata\AdminBundle\Datagrid\ListMapper;
+use Symfony\Cmf\Bundle\BlockBundle\Doctrine\Phpcr\ImagineBlock;
+use Symfony\Cmf\Bundle\MediaBundle\Form\Type\ImageType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Sonata\DoctrinePHPCRAdminBundle\Form\Type\TreeModelType;
+
+/**
+ * @author Horner
+ */
+class ImagineBlockAdmin extends AbstractBlockAdmin
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function configureListFields(ListMapper $listMapper)
+    {
+        parent::configureListFields($listMapper);
+        $listMapper
+            ->addIdentifier('id', 'text')
+            ->add('name', 'text')
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configureFormFields(FormMapper $formMapper)
+    {
+        parent::configureFormFields($formMapper);
+
+        // image is only required when creating a new item
+        // TODO: sonata is not using one admin instance per object, so this doesn't really work - https://github.com/symfony-cmf/BlockBundle/issues/151
+        $imageRequired = ($this->getSubject() && $this->getSubject()->getParentDocument()) ? false : true;
+
+        if (null === $this->getParentFieldDescription()) {
+            $formMapper
+                ->with('form.group_general')
+                    ->add(
+                        'parentDocument',
+                        TreeModelType::class,
+                        array('root_node' => $this->getRootPath(), 'choice_list' => array(), 'select_root_node' => true)
+                    )
+                    ->add('name', TextType::class)
+                ->end();
+        }
+
+        $formMapper
+            ->with('form.group_general')
+                ->add('label', TextType::class, array('required' => false))
+                ->add('linkUrl', TextType::class, array('required' => false))
+                ->add('filter', TextType::class, array('required' => false))
+                ->add('image', ImageType::class, array('required' => $imageRequired))
+                ->add('position', HiddenType::class, array('mapped' => false))
+            ->end();
+    }
+
+    public function toString($object)
+    {
+        return $object instanceof ImagineBlock && $object->getLabel()
+            ? $object->getLabel()
+            : parent::toString($object)
+        ;
+    }
+}

--- a/src/Admin/Block/Imagine/SlideshowBlockAdmin.php
+++ b/src/Admin/Block/Imagine/SlideshowBlockAdmin.php
@@ -1,0 +1,130 @@
+<?php
+
+/*
+ * This file is part of the Symfony CMF package.
+ *
+ * (c) 2011-2016 Symfony CMF
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Cmf\Bundle\BlockBundle\Admin\Imagine;
+
+use Sonata\AdminBundle\Form\FormMapper;
+use Sonata\AdminBundle\Datagrid\ListMapper;
+use Symfony\Cmf\Bundle\SonataAdminIntegrationBundle\Admin\Block\AbstractBlockAdmin;
+use Symfony\Cmf\Bundle\BlockBundle\Doctrine\Phpcr\SlideshowBlock;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Sonata\CoreBundle\Form\Type\CollectionType;
+use Sonata\DoctrinePHPCRAdminBundle\Form\Type\TreeModelType;
+
+/**
+ * @author Horner
+ */
+class SlideshowBlockAdmin extends AbstractBlockAdmin
+{
+    /**
+     * Service name of the sonata_type_collection service to embed.
+     *
+     * @var string
+     */
+    protected $embeddedAdminCode;
+
+    /**
+     * Configure the service name (admin_code) of the admin service for the embedded slides.
+     *
+     * @param string $adminCode
+     */
+    public function setEmbeddedSlidesAdmin($adminCode)
+    {
+        $this->embeddedAdminCode = $adminCode;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configureListFields(ListMapper $listMapper)
+    {
+        parent::configureListFields($listMapper);
+        $listMapper
+            ->addIdentifier('id', 'text')
+            ->add('title', 'text')
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configureFormFields(FormMapper $formMapper)
+    {
+        parent::configureFormFields($formMapper);
+
+        $formMapper
+            ->with('form.group_general')
+                ->add('title', TextType::class, array('required' => false))
+            ->end()
+            ->with('Items')
+                ->add('children', CollectionType::class,
+                    array(),
+                    array(
+                        'edit' => 'inline',
+                        'inline' => 'table',
+                        'admin_code' => $this->embeddedAdminCode,
+                        'sortable' => 'position',
+                    ))
+            ->end()
+        ;
+
+        if (null === $this->getParentFieldDescription()) {
+            $formMapper
+                ->with('form.group_general')
+                    ->add('parentDocument', TreeModelType::class, array('root_node' => $this->getRootPath(), 'choice_list' => array(), 'select_root_node' => true))
+                    ->add('name', TextType::class)
+                ->end()
+            ;
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function prePersist($slideshow)
+    {
+        foreach ($slideshow->getChildren() as $child) {
+            $child->setName($this->generateName());
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function preUpdate($slideshow)
+    {
+        foreach ($slideshow->getChildren() as $child) {
+            if (!$this->modelManager->getNormalizedIdentifier($child)) {
+                $child->setName($this->generateName());
+            }
+        }
+    }
+
+    /**
+     * Generate a most likely unique name.
+     *
+     * TODO: have blocks use the autoname annotation - https://github.com/symfony-cmf/BlockBundle/issues/149
+     *
+     * @return string
+     */
+    private function generateName()
+    {
+        return 'child_'.time().'_'.rand();
+    }
+
+    public function toString($object)
+    {
+        return $object instanceof SlideshowBlock && $object->getTitle()
+            ? $object->getTitle()
+            : parent::toString($object)
+        ;
+    }
+}

--- a/src/Admin/Block/Imagine/SlideshowBlockAdmin.php
+++ b/src/Admin/Block/Imagine/SlideshowBlockAdmin.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Cmf\Bundle\BlockBundle\Admin\Imagine;
+namespace Symfony\Cmf\Bundle\SonataAdminIntegrationBundle\Admin\Block\Imagine;
 
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\AdminBundle\Datagrid\ListMapper;

--- a/src/Admin/Block/MenuBlockAdmin.php
+++ b/src/Admin/Block/MenuBlockAdmin.php
@@ -1,0 +1,87 @@
+<?php
+
+/*
+ * This file is part of the Symfony CMF package.
+ *
+ * (c) 2011-2016 Symfony CMF
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Cmf\Bundle\SonataAdminIntegrationBundle\Admin\Block;
+
+use Sonata\AdminBundle\Datagrid\DatagridMapper;
+use Sonata\AdminBundle\Datagrid\ListMapper;
+use Sonata\AdminBundle\Form\FormMapper;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Sonata\DoctrinePHPCRAdminBundle\Form\Type\TreeModelType;
+
+/**
+ * Sonata admin for the MenuBlock. Allows to select the target menu node from
+ * an odm tree at the menu root.
+ *
+ * @author Philipp A. Mohrenweiser <phiamo@googlemail.com>
+ */
+class MenuBlockAdmin extends AbstractBlockAdmin
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function configureListFields(ListMapper $listMapper)
+    {
+        $listMapper
+            ->addIdentifier('id', 'text')
+            ->add('name', 'text')
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configureFormFields(FormMapper $formMapper)
+    {
+        $formMapper
+            ->with('form.group_general')
+                ->add('parentDocument', TreeModelType::class, array('root_node' => $this->getRootPath(), 'choice_list' => array(), 'select_root_node' => true))
+                ->add('name', TextType::class)
+                ->add('menuNode', TreeModelType::class, array('choice_list' => array(), 'required' => true, 'root_node' => $this->menuPath))
+            ->end()
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configureDatagridFilters(DatagridMapper $datagridMapper)
+    {
+        $datagridMapper
+            ->add('name', 'doctrine_phpcr_nodename')
+        ;
+    }
+
+    /**
+     * PHPCR to the root of all menu nodes for the selection of the target.
+     *
+     * @var string
+     */
+    private $menuPath;
+
+    /**
+     * Set the menu root for selection of the target of this block.
+     *
+     * @param string $menuPath
+     */
+    public function setMenuPath($menuPath)
+    {
+        $this->menuPath = $menuPath;
+    }
+
+    /**
+     * @return string
+     */
+    public function getMenuPath()
+    {
+        return $this->menuPath;
+    }
+}

--- a/src/Admin/Block/ReferenceBlockAdmin.php
+++ b/src/Admin/Block/ReferenceBlockAdmin.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of the Symfony CMF package.
+ *
+ * (c) 2011-2016 Symfony CMF
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Cmf\Bundle\SonataAdminIntegrationBundle\Admin\Block;
+
+use Sonata\AdminBundle\Datagrid\DatagridMapper;
+use Sonata\AdminBundle\Datagrid\ListMapper;
+use Sonata\AdminBundle\Form\FormMapper;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Sonata\DoctrinePHPCRAdminBundle\Form\Type\TreeModelType;
+
+/**
+ * @author Lukas Kahwe Smith <smith@pooteeweet.org>
+ */
+class ReferenceBlockAdmin extends AbstractBlockAdmin
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function configureListFields(ListMapper $listMapper)
+    {
+        $listMapper
+            ->addIdentifier('id', 'text')
+            ->add('name', 'text')
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configureFormFields(FormMapper $formMapper)
+    {
+        $formMapper
+            ->with('form.group_general')
+                ->add('parentDocument', TreeModelType::class, array('root_node' => $this->getRootPath(), 'choice_list' => array(), 'select_root_node' => true))
+                ->add('name', TextType::class)
+                ->add('referencedBlock', TreeModelType::class, array('choice_list' => array(), 'required' => false, 'root_node' => $this->getRootPath()))
+            ->end()
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configureDatagridFilters(DatagridMapper $datagridMapper)
+    {
+        $datagridMapper
+            ->add('name', 'doctrine_phpcr_nodename')
+        ;
+    }
+}

--- a/src/Admin/Block/SimpleBlockAdmin.php
+++ b/src/Admin/Block/SimpleBlockAdmin.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * This file is part of the Symfony CMF package.
+ *
+ * (c) 2011-2016 Symfony CMF
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Cmf\Bundle\SonataAdminIntegrationBundle\Admin\Block;
+
+use Sonata\AdminBundle\Datagrid\DatagridMapper;
+use Sonata\AdminBundle\Datagrid\ListMapper;
+use Sonata\AdminBundle\Form\FormMapper;
+use Symfony\Cmf\Bundle\BlockBundle\Doctrine\Phpcr\SimpleBlock;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+use Sonata\DoctrinePHPCRAdminBundle\Form\Type\TreeModelType;
+
+/**
+ * @author Lukas Kahwe Smith <smith@pooteeweet.org>
+ */
+class SimpleBlockAdmin extends AbstractBlockAdmin
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function configureListFields(ListMapper $listMapper)
+    {
+        $listMapper
+            ->addIdentifier('id', 'text')
+            ->add('title', 'text')
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configureFormFields(FormMapper $formMapper)
+    {
+        $formMapper
+            ->with('form.group_general')
+                ->add('parentDocument', TreeModelType::class, array('root_node' => $this->getRootPath(), 'choice_list' => array(), 'select_root_node' => true))
+                ->add('name', TextType::class)
+                ->add('title', TextType::class)
+                ->add('body', TextareaType::class)
+            ->end()
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configureDatagridFilters(DatagridMapper $datagridMapper)
+    {
+        $datagridMapper
+            ->add('title', 'doctrine_phpcr_string')
+            ->add('name', 'doctrine_phpcr_nodename')
+        ;
+    }
+
+    public function toString($object)
+    {
+        return $object instanceof SimpleBlock && $object->getTitle()
+            ? $object->getTitle()
+            : parent::toString($object)
+        ;
+    }
+}

--- a/src/Admin/Block/StringBlockAdmin.php
+++ b/src/Admin/Block/StringBlockAdmin.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the Symfony CMF package.
+ *
+ * (c) 2011-2016 Symfony CMF
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Cmf\Bundle\SonataAdminIntegrationBundle\Admin\Block;
+
+use Sonata\AdminBundle\Form\FormMapper;
+use Sonata\AdminBundle\Datagrid\DatagridMapper;
+use Sonata\AdminBundle\Datagrid\ListMapper;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+use Sonata\DoctrinePHPCRAdminBundle\Form\Type\TreeModelType;
+
+/**
+ * @author Daniel Leech <daniel@dantleech.com>
+ */
+class StringBlockAdmin extends AbstractBlockAdmin
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function configureListFields(ListMapper $listMapper)
+    {
+        $listMapper->addIdentifier('id', 'text');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configureFormFields(FormMapper $formMapper)
+    {
+        $formMapper
+            ->with('form.group_general')
+                ->add('parentDocument', TreeModelType::class, array('root_node' => $this->getRootPath(), 'choice_list' => array(), 'select_root_node' => true))
+                ->add('name', TextType::class)
+                ->add('body', TextareaType::class)
+            ->end()
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configureDatagridFilters(DatagridMapper $datagridMapper)
+    {
+        $datagridMapper->add('name', 'doctrine_phpcr_nodename');
+    }
+}

--- a/src/DependencyInjection/CmfSonataAdminIntegrationExtension.php
+++ b/src/DependencyInjection/CmfSonataAdminIntegrationExtension.php
@@ -100,6 +100,7 @@ class CmfSonataAdminIntegrationExtension extends Extension implements CompilerPa
             'CmfSeoBundle' => new Factory\SeoAdminFactory(),
             'CmfMenuBundle' => new Factory\MenuAdminFactory(),
             'CmfRoutingBundle' => new Factory\RoutingAdminFactory(),
+            'CmfBlockBundle' => new Factory\BlockAdminFactory(),
         ];
         $enabledBundles = $container->getParameter('kernel.bundles');
 

--- a/src/DependencyInjection/Factory/BlockAdminFactory.php
+++ b/src/DependencyInjection/Factory/BlockAdminFactory.php
@@ -1,0 +1,139 @@
+<?php
+
+/*
+ * This file is part of the Symfony CMF package.
+ *
+ * (c) 2011-2016 Symfony CMF
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Cmf\Bundle\SonataAdminIntegrationBundle\DependencyInjection\Factory;
+
+use Symfony\Component\Config\Definition\Builder\NodeBuilder;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
+
+/**
+ * @author Maximilian Berghoff <Maximilian.Berghoff@mayflower.de>
+ */
+class BlockAdminFactory implements AdminFactoryInterface
+{
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getKey()
+    {
+        return 'block';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addConfiguration(NodeBuilder $builder)
+    {
+        $builder
+            ->scalarNode('basepath')->defaultNull()->end()
+            ->scalarNode('menu_basepath')->defaultNull()->end()
+            ->enumNode('use_imagine')
+                ->values([true, false, 'auto'])
+                ->defaultValue('auto')
+            ->end()
+            ->arrayNode('admin_classes')
+                ->children()
+                    ->scalarNode('string_document_class')
+                        ->defaultValue('Symfony\Cmf\Bundle\BlockBundle\Doctrine\Phpcr\StringBlock')
+                    ->end()
+                    ->scalarNode('simple_document_class')
+                        ->defaultValue('Symfony\Cmf\Bundle\BlockBundle\Doctrine\Phpcr\SimpleBlock')
+                    ->end()
+                    ->scalarNode('container_document_class')
+                        ->defaultValue('Symfony\Cmf\Bundle\BlockBundle\Doctrine\Phpcr\ContainerBlock')
+                    ->end()
+                    ->scalarNode('reference_document_class')
+                        ->defaultValue('Symfony\Cmf\Bundle\BlockBundle\Doctrine\Phpcr\ReferenceBlock')
+                    ->end()
+                    ->scalarNode('action_document_class')
+                        ->defaultValue('Symfony\Cmf\Bundle\BlockBundle\Doctrine\Phpcr\ActionBlock')
+                    ->end()
+                    ->scalarNode('slideshow_document_class')
+                        ->defaultValue('Symfony\Cmf\Bundle\BlockBundle\Doctrine\Phpcr\SlideshowBlock')
+                    ->end()
+                    ->scalarNode('imagine_document_class')
+                        ->defaultValue('Symfony\Cmf\Bundle\BlockBundle\Doctrine\Phpcr\ImagineBlock')
+                    ->end()
+                    ->scalarNode('menu_document_class')
+                        ->defaultValue('Symfony\Cmf\Bundle\BlockBundle\Doctrine\Phpcr\MenuBlock')
+                    ->end()
+                    ->scalarNode('string_admin_class')
+                        ->defaultValue('Symfony\Cmf\Bundle\SonataAdminIntegrationBundle\Admin\Block\StringBlockAdmin')
+                    ->end()
+                    ->scalarNode('simple_admin_class')
+                        ->defaultValue('Symfony\Cmf\Bundle\SonataAdminIntegrationBundle\Admin\Block\SimpleBlockAdmin')
+                    ->end()
+                    ->scalarNode('container_admin_class')
+                        ->defaultValue('Symfony\Cmf\Bundle\SonataAdminIntegrationBundle\Admin\Block\ContainerBlockAdmin')
+                    ->end()
+                    ->scalarNode('reference_admin_class')
+                        ->defaultValue('Symfony\Cmf\Bundle\SonataAdminIntegrationBundle\Admin\Block\ReferenceBlockAdmin')
+                    ->end()
+                    ->scalarNode('action_admin_class')
+                        ->defaultValue('Symfony\Cmf\Bundle\SonataAdminIntegrationBundle\Admin\Block\ActionBlockAdmin')
+                    ->end()
+                    ->scalarNode('slideshow_admin_class')
+                        ->defaultValue('Symfony\Cmf\Bundle\SonataAdminIntegrationBundle\Admin\Block\Imagine\SlideshowBlockAdmin')
+                    ->end()
+                    ->scalarNode('imagine_admin_class')
+                        ->defaultValue('Symfony\Cmf\Bundle\SonataAdminIntegrationBundle\Admin\Block\Imagine\ImagineBlockAdmin')
+                    ->end()
+                    ->scalarNode('menu_admin_class')
+                        ->defaultValue('Symfony\Cmf\Bundle\SonataAdminIntegrationBundle\Admin\Block\MenuBlockAdmin')
+                    ->end()
+                ->end()
+            ->end();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function create(array $config, ContainerBuilder $container, XmlFileLoader $loader)
+    {
+        $container->setParameter('cmf_sonata_admin_integration.block.phpcr.basepath', $config['basepath']);
+        $container->setParameter('cmf_sonata_admin_integration.block.phpcr.menu_basepath', $config['menu_basepath']);
+        $keys = [
+            'string_document_class' => 'string_document.class',
+            'simple_document_class' => 'simple_document.class',
+            'container_document_class' => 'container_document.class',
+            'reference_document_class' => 'reference_document.class',
+            'menu_document_class' => 'menu_document.class',
+            'action_document_class' => 'action_document.class',
+            'imagine_document_class' => 'imagine_document.class',
+            'slideshow_document_class' => 'slideshow_document.class',
+            'string_admin_class' => 'string_admin.class',
+            'simple_admin_class' => 'simple_admin.class',
+            'container_admin_class' => 'container_admin.class',
+            'reference_admin_class' => 'reference_admin.class',
+            'menu_admin_class' => 'menu_admin.class',
+            'action_admin_class' => 'action_admin.class',
+            'imagine_admin_class' => 'imagine_admin.class',
+            'slideshow_admin_class' => 'slideshow_admin.class',
+        ];
+        $adminClasses = $config['admin_classes'];
+        foreach ($keys as $sourceKey => $targetKey) {
+            $container->setParameter('cmf_sonata_admin_integration.block.'.$targetKey, $adminClasses[$sourceKey]);
+        }
+
+        $bundles = $container->getParameter('kernel.bundles');
+        $loader->load('block.xml');
+
+        if ($config['use_imagine']) {
+            $loader->load('block-imagine.xml');
+        }
+
+        if (isset($bundles['CmfMenuBundle'])) {
+            $loader->load('block-menu.xml');
+        }
+    }
+}

--- a/src/DependencyInjection/Factory/BlockAdminFactory.php
+++ b/src/DependencyInjection/Factory/BlockAdminFactory.php
@@ -100,8 +100,11 @@ class BlockAdminFactory implements AdminFactoryInterface
      */
     public function create(array $config, ContainerBuilder $container, XmlFileLoader $loader)
     {
-        $container->setParameter('cmf_sonata_admin_integration.block.phpcr.basepath', $config['basepath']);
-        $container->setParameter('cmf_sonata_admin_integration.block.phpcr.menu_basepath', $config['menu_basepath']);
+        $container->setParameter('cmf_sonata_admin_integration.block.persistence.phpcr.basepath', $config['basepath']);
+        $container->setParameter(
+            'cmf_sonata_admin_integration.block.persistence.phpcr.menu_basepath',
+            $config['menu_basepath']
+        );
         $keys = [
             'string_document_class' => 'string_document.class',
             'simple_document_class' => 'simple_document.class',
@@ -120,7 +123,7 @@ class BlockAdminFactory implements AdminFactoryInterface
             'imagine_admin_class' => 'imagine_admin.class',
             'slideshow_admin_class' => 'slideshow_admin.class',
         ];
-        $adminClasses = $config['admin_classes'];
+        $adminClasses = isset($config['admin_classes']) ? $config['admin_classes'] : [];
         foreach ($keys as $sourceKey => $targetKey) {
             $container->setParameter('cmf_sonata_admin_integration.block.'.$targetKey, $adminClasses[$sourceKey]);
         }

--- a/src/Resources/config/block-imagine.xml
+++ b/src/Resources/config/block-imagine.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+
+        <service
+                id="cmf_sonata_admin_integration.block.imagine.slideshow_admin"
+                class="%cmf_sonata_admin_integration.block.slideshow_admin.class%">
+            <tag
+                    name="sonata.admin"
+                    manager_type="doctrine_phpcr"
+                    group="dashboard.cmf"
+                    label_catalogue="CmfBlockBundle"
+                    label="dashboard.label_slideshow_block"
+                    label_translator_strategy="sonata.admin.label.strategy.underscore" />
+            <argument/>
+            <argument>%cmf_sonata_admin_integration.block.slideshow_document.class%</argument>
+            <argument>SonataAdminBundle:CRUD</argument>
+
+            <call method="setRouteBuilder">
+                <argument type="service" id="sonata.admin.route.path_info_slashes" />
+            </call>
+
+            <call method="setEmbeddedSlidesAdmin">
+                <argument>cmf_block.imagine.imagine_admin</argument>
+            </call>
+
+            <call method="setRootPath">
+                <argument>%cmf_sonata_admin_integration.block.persistence.phpcr.basepath%</argument>
+            </call>
+        </service>
+
+        <service
+                id="cmf_sonata_admin_integration.block.imagine.imagine_admin"
+                class="%cmf_sonata_admin_integration.block.imagine_admin.class%">
+            <tag
+                    name="sonata.admin"
+                    manager_type="doctrine_phpcr"
+                    group="dashboard.cmf"
+                    label_catalogue="CmfBlockBundle"
+                    label="dashboard.label_imagine_block"
+                    label_translator_strategy="sonata.admin.label.strategy.underscore" />
+            <argument/>
+            <argument>%cmf_sonata_admin_integration.block.imagine_document.class%</argument>
+            <argument>SonataAdminBundle:CRUD</argument>
+
+            <call method="setRouteBuilder">
+                <argument type="service" id="sonata.admin.route.path_info_slashes" />
+            </call>
+
+            <call method="setRootPath">
+                <argument>%cmf_sonata_admin_integration.block.persistence.phpcr.basepath%</argument>
+            </call>
+        </service>
+
+    </services>
+</container>

--- a/src/Resources/config/block-menu.xml
+++ b/src/Resources/config/block-menu.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <service
+                id="cmf_sonata_admin_integration.block.menu_admin"
+                class="%cmf_sonata_admin_integration.block.menu_admin.class%">
+            <tag
+                    name="sonata.admin"
+                    manager_type="doctrine_phpcr"
+                    group="dashboard.cmf"
+                    label_catalogue="CmfBlockBundle"
+                    label="dashboard.label_menu_block"
+                    label_translator_strategy="sonata.admin.label.strategy.underscore" />
+            <argument/>
+            <argument>%cmf_sonata_admin_integration.block.menu_document.class%</argument>
+            <argument>SonataAdminBundle:CRUD</argument>
+
+            <call method="setRouteBuilder">
+                <argument type="service" id="sonata.admin.route.path_info_slashes" />
+            </call>
+
+            <call method="setRootPath">
+                <argument>%cmf_sonata_admin_integration.block.persistence.phpcr.basepath%</argument>
+            </call>
+            <call method="setMenuPath">
+                <argument>%cmf_sonata_admin_integration.block.persistence.phpcr.menu_basepath%</argument>
+            </call>
+        </service>
+    </services>
+</container>

--- a/src/Resources/config/block.xml
+++ b/src/Resources/config/block.xml
@@ -1,0 +1,131 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+
+        <service
+                id="cmf_sonata_admin_integration.block.admin_extension.cache"
+                class="Symfony\Cmf\Bundle\SonataAdminIntegrationBundle\Admin\Block\Extension\BlockCacheExtension">
+            <tag name="sonata.admin.extension"/>
+        </service>
+
+        <service
+                id="cmf_sonata_admin_integration.block.simple_admin"
+                class="%cmf_sonata_admin_integration.block.simple_admin.class%">
+            <tag
+                    name="sonata.admin"
+                    manager_type="doctrine_phpcr"
+                    group="dashboard.cmf"
+                    label_catalogue="CmfBlockBundle"
+                    label="dashboard.label_simple_block"
+                    label_translator_strategy="sonata.admin.label.strategy.underscore" />
+            <argument/>
+            <argument>%cmf_sonata_admin_integration.block.simple_document.class%</argument>
+            <argument>SonataAdminBundle:CRUD</argument>
+
+            <call method="setRouteBuilder">
+                <argument type="service" id="sonata.admin.route.path_info_slashes" />
+            </call>
+
+            <call method="setRootPath">
+                <argument>%cmf_sonata_admin_integration.block.persistence.phpcr.basepath%</argument>
+            </call>
+        </service>
+
+        <service
+                id="cmf_sonata_admin_integration.block.action_admin"
+                class="%cmf_sonata_admin_integration.block.action_admin.class%">
+            <tag
+                    name="sonata.admin"
+                    manager_type="doctrine_phpcr"
+                    group="dashboard.cmf"
+                    label_catalogue="CmfBlockBundle"
+                    label="dashboard.label_action_block"
+                    label_translator_strategy="sonata.admin.label.strategy.underscore" />
+            <argument/>
+            <argument>%cmf_sonata_admin_integration.block.action_document.class%</argument>
+            <argument>SonataAdminBundle:CRUD</argument>
+
+            <call method="setRouteBuilder">
+                <argument type="service" id="sonata.admin.route.path_info_slashes" />
+            </call>
+
+            <call method="setRootPath">
+                <argument>%cmf_sonata_admin_integration.block.persistence.phpcr.basepath%</argument>
+            </call>
+        </service>
+
+        <service
+                id="cmf_sonata_admin_integration.block.container_admin"
+                class="%cmf_sonata_admin_integration.block.container_admin.class%">
+            <tag
+                    name="sonata.admin"
+                    manager_type="doctrine_phpcr"
+                    group="dashboard.cmf"
+                    label_catalogue="CmfBlockBundle"
+                    label="dashboard.label_container_block"
+                    label_translator_strategy="sonata.admin.label.strategy.underscore" />
+            <argument/>
+            <argument>%cmf_sonata_admin_integration.block.container_document.class%</argument>
+            <argument>SonataAdminBundle:CRUD</argument>
+
+            <call method="setRouteBuilder">
+                <argument type="service" id="sonata.admin.route.path_info_slashes" />
+            </call>
+
+            <call method="setRootPath">
+                <argument>%cmf_sonata_admin_integration.basepath%</argument>
+            </call>
+        </service>
+
+        <service
+                id="cmf_sonata_admin_integration.block.reference_admin"
+                class="%cmf_sonata_admin_integration.block.reference_admin.class%">
+            <tag
+                    name="sonata.admin"
+                    manager_type="doctrine_phpcr"
+                    group="dashboard.cmf"
+                    label_catalogue="CmfBlockBundle"
+                    label="dashboard.label_reference_block"
+                    label_translator_strategy="sonata.admin.label.strategy.underscore" />
+            <argument/>
+            <argument>%cmf_sonata_admin_integration.block.reference_document.class%</argument>
+            <argument>SonataAdminBundle:CRUD</argument>
+
+            <call method="setRouteBuilder">
+                <argument type="service" id="sonata.admin.route.path_info_slashes" />
+            </call>
+
+            <call method="setRootPath">
+                <argument>%cmf_sonata_admin_integration.block.persistence.phpcr.basepath%</argument>
+            </call>
+        </service>
+
+        <service
+                id="cmf_sonata_admin_integration.block.string_admin"
+                class="%cmf_sonata_admin_integration.block.string_admin.class%">
+            <tag
+                    name="sonata.admin"
+                    manager_type="doctrine_phpcr"
+                    group="dashboard.cmf"
+                    label_catalogue="CmfBlockBundle"
+                    label="dashboard.label_string_block"
+                    label_translator_strategy="sonata.admin.label.strategy.underscore" />
+            <argument/>
+            <argument>%cmf_sonata_admin_integration.block.string_document.class%</argument>
+            <argument>SonataAdminBundle:CRUD</argument>
+
+            <call method="setRouteBuilder">
+                <argument type="service" id="sonata.admin.route.path_info_slashes" />
+            </call>
+
+            <call method="setRootPath">
+                <argument>%cmf_sonata_admin_integration.block.persistence.phpcr.basepath%</argument>
+            </call>
+        </service>
+
+    </services>
+</container>

--- a/src/Resources/config/block.xml
+++ b/src/Resources/config/block.xml
@@ -77,7 +77,7 @@
             </call>
 
             <call method="setRootPath">
-                <argument>%cmf_sonata_admin_integration.basepath%</argument>
+                <argument>%cmf_sonata_admin_integration.block.persistence.phpcr.basepath%</argument>
             </call>
         </service>
 

--- a/tests/Resources/DataFixtures/Phpcr/LoadBlockData.php
+++ b/tests/Resources/DataFixtures/Phpcr/LoadBlockData.php
@@ -1,0 +1,156 @@
+<?php
+
+/*
+ * This file is part of the Symfony CMF package.
+ *
+ * (c) 2011-2016 Symfony CMF
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Cmf\Bundle\SonataAdminIntegrationBundle\Tests\Resources\DataFixtures\Phpcr;
+
+use Doctrine\Common\DataFixtures\FixtureInterface;
+use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\ODM\PHPCR\Document\Generic;
+use PHPCR\Util\NodeHelper;
+use Symfony\Cmf\Bundle\BlockBundle\Doctrine\Phpcr\ActionBlock;
+use Symfony\Cmf\Bundle\BlockBundle\Doctrine\Phpcr\ContainerBlock;
+use Symfony\Cmf\Bundle\BlockBundle\Doctrine\Phpcr\MenuBlock;
+use Symfony\Cmf\Bundle\BlockBundle\Doctrine\Phpcr\ReferenceBlock;
+use Symfony\Cmf\Bundle\BlockBundle\Doctrine\Phpcr\SimpleBlock;
+use Symfony\Cmf\Bundle\BlockBundle\Doctrine\Phpcr\StringBlock;
+use Symfony\Cmf\Bundle\MenuBundle\Doctrine\Phpcr\Menu;
+use Symfony\Cmf\Bundle\MenuBundle\Doctrine\Phpcr\MenuNode;
+
+/**
+ * @author David Buchmann <david@liip.ch>
+ */
+class LoadBlockData implements FixtureInterface
+{
+    public function load(ObjectManager $manager)
+    {
+        NodeHelper::createPath($manager->getPhpcrSession(), '/test');
+
+        $root = $manager->find(null, '/test');
+        $parent = new Generic();
+        $parent->setParentDocument($root);
+        $parent->setNodename('blocks');
+        $manager->persist($parent);
+
+        //Simple
+        $block = new SimpleBlock();
+        $block->setParentDocument($parent);
+        $block->setName('block-1');
+        $block->setTitle('block-1-title');
+        $block->setBody('block-1-body');
+        $manager->persist($block);
+
+        $block = new SimpleBlock();
+        $block->setParentDocument($parent);
+        $block->setName('block-2');
+        $block->setTitle('block-2-title');
+        $block->setBody('block-2-body');
+        $block->setPublishable(false);
+        $manager->persist($block);
+
+        //Action
+        $actionBlockOne = new ActionBlock();
+        $actionBlockOne->setParentDocument($parent);
+        $actionBlockOne->setName('action-block-1');
+        $actionBlockOne->setActionName('cmf_block_test.test_controller:dummyAction');
+        $actionBlockOne->setPublishable(true);
+        $manager->persist($actionBlockOne);
+
+        $actionBlockTwo = new ActionBlock();
+        $actionBlockTwo->setParentDocument($parent);
+        $actionBlockTwo->setName('action-block-2');
+        $actionBlockTwo->setActionName('FooBundle:Bar:actionTwo');
+        $actionBlockTwo->setPublishable(false);
+        $manager->persist($actionBlockTwo);
+
+        //Container
+        $childBlockOne = new SimpleBlock();
+        $childBlockOne->setName('block-child-1');
+        $childBlockOne->setTitle('block-child-1-title');
+        $childBlockOne->setBody('block-child-1-body');
+
+        $containerBlock = new ContainerBlock();
+        $containerBlock->setParentDocument($parent);
+        $containerBlock->setName('container-block-1');
+        $containerBlock->addChild($childBlockOne);
+        $manager->persist($containerBlock);
+
+        $block = new ContainerBlock();
+        $block->setParentDocument($parent);
+        $block->setName('container-block-2');
+        $block->setPublishable(false);
+        $manager->persist($block);
+
+        //Reference
+        $block = new ReferenceBlock();
+        $block->setParentDocument($parent);
+        $block->setName('reference-block-1');
+        $block->setReferencedBlock($actionBlockOne);
+        $manager->persist($block);
+
+        $block = new ReferenceBlock();
+        $block->setParentDocument($parent);
+        $block->setName('reference-block-2');
+        $block->setReferencedBlock($actionBlockTwo);
+        $block->setPublishable(false);
+        $manager->persist($block);
+
+        // Menu Nodes
+        NodeHelper::createPath($manager->getPhpcrSession(), '/test/menus');
+        $menuRoot = $manager->find(null, '/test/menus');
+        $menu = new Menu();
+        $menu->setName('test-menu');
+        $menu->setLabel('Test Menu');
+        $menu->setParentDocument($menuRoot);
+        $manager->persist($menu);
+
+        $menuNodeOne = new MenuNode();
+        $menuNodeOne->setName('menu-node-1');
+        $menuNodeOne->setLabel('menu-node-1');
+        $menuNodeOne->setParentDocument($menu);
+        $manager->persist($menuNodeOne);
+
+        $menuNodeTwo = new MenuNode();
+        $menuNodeTwo->setName('menu-node-2');
+        $menuNodeTwo->setLabel('menu-node-2');
+        $menuNodeTwo->setParentDocument($menu);
+        $manager->persist($menuNodeTwo);
+
+        //Menu
+        $block = new MenuBlock();
+        $block->setParentDocument($parent);
+        $block->setName('menu-block-1');
+        $block->setMenuNode($menuNodeOne);
+        $manager->persist($block);
+
+        $block = new MenuBlock();
+        $block->setParentDocument($parent);
+        $block->setName('menu-block-2');
+        $block->setMenuNode($menuNodeTwo);
+        $block->setPublishable(false);
+        $manager->persist($block);
+
+        //String
+        $block = new StringBlock();
+        $block->setParentDocument($parent);
+        $block->setName('string-block-1');
+        $block->setBody('string-block-1-body');
+        $manager->persist($block);
+
+        $block = new StringBlock();
+        $block->setParentDocument($parent);
+        $block->setName('string-block-2');
+        $block->setBody('string-block-2-body');
+        $block->setPublishable(false);
+        $manager->persist($block);
+
+        $manager->flush();
+    }
+}

--- a/tests/Resources/app/AppKernel.php
+++ b/tests/Resources/app/AppKernel.php
@@ -50,5 +50,6 @@ class AppKernel extends TestKernel
     {
         $loader->load(__DIR__.'/config/config.php');
         $loader->load(__DIR__.'/config/config_'.$this->environment.'.php');
+        $loader->load(__DIR__.'/config/admin-test.xml');
     }
 }

--- a/tests/Resources/app/AppKernel.php
+++ b/tests/Resources/app/AppKernel.php
@@ -34,6 +34,7 @@ class AppKernel extends TestKernel
             new Symfony\Cmf\Bundle\MenuBundle\CmfMenuBundle(),
             new Symfony\Cmf\Bundle\RoutingBundle\CmfRoutingBundle(),
             new Symfony\Cmf\Bundle\CoreBundle\CmfCoreBundle(),
+            new Symfony\Cmf\Bundle\BlockBundle\CmfBlockBundle(),
             new Burgov\Bundle\KeyValueFormBundle\BurgovKeyValueFormBundle(),
         ));
 

--- a/tests/Resources/app/config/admin-test.xml
+++ b/tests/Resources/app/config/admin-test.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <service id="cmf_block_test.test_controller" class="Symfony\Cmf\Bundle\BlockBundle\Tests\Resources\Controller\TestController" />
+    </services>
+
+</container>

--- a/tests/Resources/app/config/cmf_sonata_admin_integration.phpcr.yml
+++ b/tests/Resources/app/config/cmf_sonata_admin_integration.phpcr.yml
@@ -68,7 +68,7 @@ cmf_sonata_admin_integration:
         routing:
             basepath: /test/routing
         block:
-            basepath: /test/blocka
+            basepath: /test/blocks
             menu_basepath: /test/menus
             use_imagine: true
             admin_classes: ~

--- a/tests/Resources/app/config/cmf_sonata_admin_integration.phpcr.yml
+++ b/tests/Resources/app/config/cmf_sonata_admin_integration.phpcr.yml
@@ -67,3 +67,8 @@ cmf_sonata_admin_integration:
         menu: ~
         routing:
             basepath: /test/routing
+        block:
+            basepath: /test/block
+            menu_basepath: /test/menu_block
+            use_imagine: true
+            admin_classes: ~

--- a/tests/Resources/app/config/cmf_sonata_admin_integration.phpcr.yml
+++ b/tests/Resources/app/config/cmf_sonata_admin_integration.phpcr.yml
@@ -68,7 +68,7 @@ cmf_sonata_admin_integration:
         routing:
             basepath: /test/routing
         block:
-            basepath: /test/block
-            menu_basepath: /test/menu_block
+            basepath: /test/blocka
+            menu_basepath: /test/menus
             use_imagine: true
             admin_classes: ~

--- a/tests/Unit/DependencyInjection/CmfSonataAdminExtensionTest.php
+++ b/tests/Unit/DependencyInjection/CmfSonataAdminExtensionTest.php
@@ -93,12 +93,6 @@ class CmfSonataAdminExtensionTest extends AbstractExtensionTestCase
             ],
         ]);
 
-        $this->assertContainerBuilderHasParameter('cmf_sonata_admin_integration.block.phpcr.basepath', 'basepath_value');
-        $this->assertContainerBuilderHasParameter(
-            'cmf_sonata_admin_integration.block.phpcr.menu_basepath',
-            'menu_basepath_value'
-        );
-
         $keys = [
             'string_document.class' => 'string_document_class_value',
             'simple_document.class' => 'simple_document_class_value',
@@ -116,14 +110,17 @@ class CmfSonataAdminExtensionTest extends AbstractExtensionTestCase
             'action_admin.class' => 'action_admin_class_value',
             'imagine_admin.class' => 'imagine_admin_class_value',
             'slideshow_admin.class' => 'slideshow_admin_class_value',
+            'persistence.phpcr.basepath' => 'basepath_value',
+            'persistence.phpcr.menu_basepath' => 'menu_basepath_value',
+
         ];
 
-        foreach ($keys as $suffix => $className) {
+        foreach ($keys as $suffix => $value) {
             $this->assertContainerBuilderHasParameter(
                 'cmf_sonata_admin_integration.block.'.$suffix,
-                $className
+                $value
             );
-            if (preg_match('/_document/', $suffix)) {
+            if (preg_match('/_document/', $suffix) || preg_match('/persistence.phpcr/', $suffix)) {
                 continue;
             }
             if (in_array($suffix, ['imagine_admin.class', 'slideshow_admin.class'])) {
@@ -131,7 +128,7 @@ class CmfSonataAdminExtensionTest extends AbstractExtensionTestCase
             }
             $this->assertContainerBuilderHasService(
                 'cmf_sonata_admin_integration.block.'.str_replace('.class', '', $suffix),
-                $className
+                $value
             );
         }
     }

--- a/tests/Unit/DependencyInjection/CmfSonataAdminExtensionTest.php
+++ b/tests/Unit/DependencyInjection/CmfSonataAdminExtensionTest.php
@@ -50,4 +50,89 @@ class CmfSonataAdminExtensionTest extends AbstractExtensionTestCase
 
         $this->assertContainerBuilderHasParameter('cmf_sonata_admin_integration.seo.form_group', 'seo_form');
     }
+
+    public function testBlockBundle()
+    {
+        $this->container->setParameter(
+            'kernel.bundles',
+            [
+                'CmfBlockBundle' => true,
+                'CmfMenuBundle' => true,
+                'CmfRoutingBundle' => true,
+                'SonataDoctrinePHPCRAdminBundle' => true,
+                'DoctrinePHPCRBundle' => true,
+            ]
+        );
+
+        $this->load([
+            'bundles' => [
+                'block' => [
+                    'enabled' => true,
+                    'use_imagine' => true,
+                    'basepath' => 'basepath_value',
+                    'menu_basepath' => 'menu_basepath_value',
+                    'admin_classes' => [
+                        'string_document_class' => 'string_document_class_value',
+                        'simple_document_class' => 'simple_document_class_value',
+                        'container_document_class' => 'container_document_class_value',
+                        'reference_document_class' => 'reference_document_class_value',
+                        'menu_document_class' => 'menu_document_class_value',
+                        'action_document_class' => 'action_document_class_value',
+                        'imagine_document_class' => 'imagine_document_class_value',
+                        'slideshow_document_class' => 'slideshow_document_class_value',
+                        'string_admin_class' => 'string_admin_class_value',
+                        'simple_admin_class' => 'simple_admin_class_value',
+                        'container_admin_class' => 'container_admin_class_value',
+                        'reference_admin_class' => 'reference_admin_class_value',
+                        'menu_admin_class' => 'menu_admin_class_value',
+                        'action_admin_class' => 'action_admin_class_value',
+                        'imagine_admin_class' => 'imagine_admin_class_value',
+                        'slideshow_admin_class' => 'slideshow_admin_class_value',
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->assertContainerBuilderHasParameter('cmf_sonata_admin_integration.block.phpcr.basepath', 'basepath_value');
+        $this->assertContainerBuilderHasParameter(
+            'cmf_sonata_admin_integration.block.phpcr.menu_basepath',
+            'menu_basepath_value'
+        );
+
+        $keys = [
+            'string_document.class' => 'string_document_class_value',
+            'simple_document.class' => 'simple_document_class_value',
+            'container_document.class' => 'container_document_class_value',
+            'reference_document.class' => 'reference_document_class_value',
+            'menu_document.class' => 'menu_document_class_value',
+            'action_document.class' => 'action_document_class_value',
+            'imagine_document.class' => 'imagine_document_class_value',
+            'slideshow_document.class' => 'slideshow_document_class_value',
+            'string_admin.class' => 'string_admin_class_value',
+            'simple_admin.class' => 'simple_admin_class_value',
+            'container_admin.class' => 'container_admin_class_value',
+            'reference_admin.class' => 'reference_admin_class_value',
+            'menu_admin.class' => 'menu_admin_class_value',
+            'action_admin.class' => 'action_admin_class_value',
+            'imagine_admin.class' => 'imagine_admin_class_value',
+            'slideshow_admin.class' => 'slideshow_admin_class_value',
+        ];
+
+        foreach ($keys as $suffix => $className) {
+            $this->assertContainerBuilderHasParameter(
+                'cmf_sonata_admin_integration.block.'.$suffix,
+                $className
+            );
+            if (preg_match('/_document/', $suffix)) {
+                continue;
+            }
+            if (in_array($suffix, ['imagine_admin.class', 'slideshow_admin.class'])) {
+                $suffix = 'imagine.'.$suffix;
+            }
+            $this->assertContainerBuilderHasService(
+                'cmf_sonata_admin_integration.block.'.str_replace('.class', '', $suffix),
+                $className
+            );
+        }
+    }
 }

--- a/tests/WebTest/Admin/Block/AbstractBlockAdminTestCase.php
+++ b/tests/WebTest/Admin/Block/AbstractBlockAdminTestCase.php
@@ -3,13 +3,13 @@
 /*
  * This file is part of the Symfony CMF package.
  *
- * (c) 2011-2015 Symfony CMF
+ * (c) 2011-2016 Symfony CMF
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Cmf\Bundle\BlockBundle\Tests\WebTest\Admin;
+namespace Symfony\Cmf\Bundle\SonataAdminIntegrationBundle\Tests\WebTest\Admin\Block;
 
 use Symfony\Bundle\FrameworkBundle\Client;
 use Symfony\Cmf\Component\Testing\Functional\BaseTestCase;
@@ -55,7 +55,7 @@ abstract class AbstractBlockAdminTestCase extends BaseTestCase
     public function setUp()
     {
         $this->db('PHPCR')->loadFixtures(array(
-            'Symfony\Cmf\Bundle\BlockBundle\Tests\Resources\DataFixtures\Phpcr\LoadBlockData',
+            'Symfony\Cmf\Bundle\SonataAdminIntegrationBundle\Tests\Resources\DataFixtures\Phpcr\LoadBlockData',
         ));
         $this->client = $this->createClient();
     }

--- a/tests/WebTest/Admin/Block/AbstractBlockAdminTestCase.php
+++ b/tests/WebTest/Admin/Block/AbstractBlockAdminTestCase.php
@@ -1,0 +1,163 @@
+<?php
+
+/*
+ * This file is part of the Symfony CMF package.
+ *
+ * (c) 2011-2015 Symfony CMF
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Cmf\Bundle\BlockBundle\Tests\WebTest\Admin;
+
+use Symfony\Bundle\FrameworkBundle\Client;
+use Symfony\Cmf\Component\Testing\Functional\BaseTestCase;
+
+/**
+ * @author Nicolas Bastien <nbastien@prestaconcept.net>
+ */
+abstract class AbstractBlockAdminTestCase extends BaseTestCase
+{
+    /**
+     * @var Client
+     */
+    protected $client;
+
+    /**
+     * Admin listing test case.
+     */
+    abstract public function testBlockList();
+
+    /**
+     * Admin edition test case.
+     */
+    abstract public function testBlockEdit();
+
+    /**
+     * Admin creation test case.
+     */
+    abstract public function testBlockCreate();
+
+    /**
+     * Admin deletion test case.
+     */
+    abstract public function testBlockDelete();
+
+    /**
+     * Admin show test case.
+     */
+    abstract public function testBlockShow();
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setUp()
+    {
+        $this->db('PHPCR')->loadFixtures(array(
+            'Symfony\Cmf\Bundle\BlockBundle\Tests\Resources\DataFixtures\Phpcr\LoadBlockData',
+        ));
+        $this->client = $this->createClient();
+    }
+
+    /**
+     * Make defaults listing assertions.
+     *
+     * @param $url              string the listing url
+     * @param $containsElements array  an array of models identifier which should be in the listing
+     */
+    protected function makeListAssertions($url, $containsElements)
+    {
+        $crawler = $this->client->request('GET', $url);
+        $res = $this->client->getResponse();
+        $this->assertResponseSuccess($res);
+
+        foreach ($containsElements as $element) {
+            $this->assertCount(1, $crawler->filter('html:contains("'.$element.'")'), $res->getContent());
+        }
+    }
+
+    /**
+     * Make defaults edition assertions.
+     *
+     * @param $url            string the edition url
+     * @param $containsValues array  an array of values which should be in the inputs
+     */
+    protected function makeEditAssertions($url, $containsValues)
+    {
+        $crawler = $this->client->request('GET', $url);
+        $res = $this->client->getResponse();
+        $this->assertResponseSuccess($res);
+
+        foreach ($containsValues as $value) {
+            $this->assertCount(1, $crawler->filter('input[value="'.$value.'"]'), $res->getContent());
+        }
+    }
+
+    /**
+     * Make defaults creation assertions.
+     *
+     * @param $url        string the creation url
+     * @param $formValues array  an array of values which should validate the form
+     */
+    protected function makeCreateAssertions($url, $formValues)
+    {
+        $crawler = $this->client->request('GET', $url);
+        $res = $this->client->getResponse();
+        $this->assertResponseSuccess($res);
+
+        $button = $crawler->selectButton('Create');
+        $form = $button->form();
+        $node = $form->getFormNode();
+        $actionUrl = $node->getAttribute('action');
+        $uniqId = substr(strstr($actionUrl, '='), 1);
+
+        foreach ($formValues as $key => $value) {
+            $form[$uniqId.'['.$key.']'] = $value;
+        }
+
+        $this->client->submit($form);
+        $res = $this->client->getResponse();
+
+        // If we have a 302 redirect, then all is well
+        $this->assertEquals(302, $res->getStatusCode(), $res->getContent());
+    }
+
+    /**
+     * Make defaults deletion assertions.
+     *
+     * @param $url string the deletion url
+     */
+    protected function makeDeleteAssertions($url)
+    {
+        $crawler = $this->client->request('GET', $url);
+        $res = $this->client->getResponse();
+        $this->assertResponseSuccess($res);
+
+        $button = $crawler->selectButton('Yes, delete');
+        $form = $button->form();
+
+        $this->client->submit($form);
+        $res = $this->client->getResponse();
+
+        // If we have a 302 redirect, then all is well
+        $this->assertEquals(302, $res->getStatusCode(), $res->getContent());
+    }
+
+    /**
+     * Make defaults show assertions.
+     *
+     * @param $url              string the edition url
+     * @param $containsElements array  an array of elements which should be in the show page
+     */
+    protected function makeShowAssertions($url, $containsElements)
+    {
+        $crawler = $this->client->request('GET', $url);
+        $res = $this->client->getResponse();
+        $this->assertResponseSuccess($res);
+
+        foreach ($containsElements as $element) {
+            $this->assertCount(1, $crawler->filter('html:contains("'.$element.'")'), $res->getContent());
+        }
+    }
+}

--- a/tests/WebTest/Admin/Block/ActionBlockAdminTest.php
+++ b/tests/WebTest/Admin/Block/ActionBlockAdminTest.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * This file is part of the Symfony CMF package.
+ *
+ * (c) 2011-2015 Symfony CMF
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Cmf\Bundle\BlockBundle\Tests\WebTest\Admin;
+
+/**
+ * @author Nicolas Bastien <nbastien@prestaconcept.net>
+ */
+class ActionBlockAdminTest extends AbstractBlockAdminTestCase
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function testBlockList()
+    {
+        $this->makeListAssertions(
+            '/admin/cmf/block/actionblock/list',
+            array('action-block-1', 'cmf_block_test.test_controller:dummyAction', 'action-block-2')
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function testBlockEdit()
+    {
+        $this->makeEditAssertions(
+            '/admin/cmf/block/actionblock/test/blocks/action-block-1/edit',
+            array('action-block-1', 'cmf_block_test.test_controller:dummyAction')
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function testBlockCreate()
+    {
+        $this->makeCreateAssertions(
+            '/admin/cmf/block/actionblock/create',
+            array(
+                'parentDocument' => '/test/blocks',
+                'name' => 'foo-test-action',
+                'actionName' => 'FooTestBunlde:Bar:action',
+            )
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function testBlockDelete()
+    {
+        $this->makeDeleteAssertions('/admin/cmf/block/actionblock/test/blocks/action-block-1/delete');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function testBlockShow()
+    {
+        $this->makeShowAssertions(
+            '/admin/cmf/block/actionblock/test/blocks/action-block-1/show',
+            array('action-block-1')
+        );
+    }
+}

--- a/tests/WebTest/Admin/Block/ActionBlockAdminTest.php
+++ b/tests/WebTest/Admin/Block/ActionBlockAdminTest.php
@@ -3,13 +3,13 @@
 /*
  * This file is part of the Symfony CMF package.
  *
- * (c) 2011-2015 Symfony CMF
+ * (c) 2011-2016 Symfony CMF
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Cmf\Bundle\BlockBundle\Tests\WebTest\Admin;
+namespace Symfony\Cmf\Bundle\SonataAdminIntegrationBundle\Tests\WebTest\Admin\Block;
 
 /**
  * @author Nicolas Bastien <nbastien@prestaconcept.net>

--- a/tests/WebTest/Admin/Block/ContainerBlockAdminTest.php
+++ b/tests/WebTest/Admin/Block/ContainerBlockAdminTest.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * This file is part of the Symfony CMF package.
+ *
+ * (c) 2011-2015 Symfony CMF
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Cmf\Bundle\BlockBundle\Tests\WebTest\Admin;
+
+/**
+ * @author Nicolas Bastien <nbastien@prestaconcept.net>
+ */
+class ContainerBlockAdminTest extends AbstractBlockAdminTestCase
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function testBlockList()
+    {
+        $this->makeListAssertions(
+            '/admin/cmf/block/containerblock/list',
+            array('container-block-1', 'container-block-2')
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function testBlockEdit()
+    {
+        $this->makeEditAssertions(
+            '/admin/cmf/block/containerblock/test/blocks/container-block-1/edit',
+            array('container-block-1')
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function testBlockCreate()
+    {
+        $this->makeCreateAssertions(
+            '/admin/cmf/block/containerblock/create',
+            array(
+                'parentDocument' => '/test/blocks',
+                'name' => 'foo-test-container',
+            )
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function testBlockDelete()
+    {
+        $this->makeDeleteAssertions('/admin/cmf/block/containerblock/test/blocks/container-block-1/delete');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function testBlockShow()
+    {
+        $this->makeShowAssertions(
+            '/admin/cmf/block/containerblock/test/blocks/container-block-1/show',
+            array('container-block-1')
+        );
+    }
+}

--- a/tests/WebTest/Admin/Block/ContainerBlockAdminTest.php
+++ b/tests/WebTest/Admin/Block/ContainerBlockAdminTest.php
@@ -3,13 +3,13 @@
 /*
  * This file is part of the Symfony CMF package.
  *
- * (c) 2011-2015 Symfony CMF
+ * (c) 2011-2016 Symfony CMF
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Cmf\Bundle\BlockBundle\Tests\WebTest\Admin;
+namespace Symfony\Cmf\Bundle\SonataAdminIntegrationBundle\Tests\WebTest\Admin\Block;
 
 /**
  * @author Nicolas Bastien <nbastien@prestaconcept.net>

--- a/tests/WebTest/Admin/Block/MenuBlockAdminTest.php
+++ b/tests/WebTest/Admin/Block/MenuBlockAdminTest.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * This file is part of the Symfony CMF package.
+ *
+ * (c) 2011-2015 Symfony CMF
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Cmf\Bundle\BlockBundle\Tests\WebTest\Admin;
+
+/**
+ * @author Nicolas Bastien <nbastien@prestaconcept.net>
+ */
+class MenuBlockAdminTest extends AbstractBlockAdminTestCase
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function testBlockList()
+    {
+        $this->makeListAssertions(
+            '/admin/cmf/block/menublock/list',
+            array('menu-block-1', 'menu-block-2')
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function testBlockEdit()
+    {
+        $this->makeEditAssertions(
+            '/admin/cmf/block/menublock/test/blocks/menu-block-1/edit',
+            array('menu-block-1')
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function testBlockCreate()
+    {
+        $this->makeCreateAssertions(
+            '/admin/cmf/block/menublock/create',
+            array(
+                'parentDocument' => '/test/blocks',
+                'name' => 'foo-test-container',
+            )
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function testBlockDelete()
+    {
+        $this->makeDeleteAssertions('/admin/cmf/block/menublock/test/blocks/menu-block-1/delete');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function testBlockShow()
+    {
+        $this->makeShowAssertions(
+            '/admin/cmf/block/menublock/test/blocks/menu-block-1/show',
+            array('menu-block-1')
+        );
+    }
+}

--- a/tests/WebTest/Admin/Block/MenuBlockAdminTest.php
+++ b/tests/WebTest/Admin/Block/MenuBlockAdminTest.php
@@ -3,13 +3,13 @@
 /*
  * This file is part of the Symfony CMF package.
  *
- * (c) 2011-2015 Symfony CMF
+ * (c) 2011-2016 Symfony CMF
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Cmf\Bundle\BlockBundle\Tests\WebTest\Admin;
+namespace Symfony\Cmf\Bundle\SonataAdminIntegrationBundle\Tests\WebTest\Admin\Block;
 
 /**
  * @author Nicolas Bastien <nbastien@prestaconcept.net>

--- a/tests/WebTest/Admin/Block/PHPCRBlockLoaderTest.php
+++ b/tests/WebTest/Admin/Block/PHPCRBlockLoaderTest.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Symfony CMF package.
+ *
+ * (c) 2011-2015 Symfony CMF
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Cmf\Bundle\BlockBundle\Tests\WebTest\Admin;
+
+use Symfony\Cmf\Bundle\BlockBundle\Block\PhpcrBlockLoader;
+use Symfony\Cmf\Component\Testing\Functional\BaseTestCase;
+use Symfony\Bundle\FrameworkBundle\Client;
+
+class PHPCRBlockLoaderTest extends BaseTestCase
+{
+    public function setUp()
+    {
+        $this->db('PHPCR')->loadFixtures(array(
+            'Symfony\Cmf\Bundle\BlockBundle\Tests\Resources\DataFixtures\Phpcr\LoadBlockData',
+        ));
+        $this->client = $this->createClient();
+    }
+
+    public function testGetUnpublished()
+    {
+        /** @var $service PhpcrBlockLoader */
+        $service = $this->client->getContainer()->get('cmf.block.service');
+        $this->assertInstanceOf('Symfony\Cmf\Bundle\BlockBundle\Doctrine\Phpcr\SimpleBlock', $service->load(array('name' => '/test/blocks/block-1')));
+        // this block is not published, should be empty
+        $this->assertInstanceOf('Sonata\BlockBundle\Model\EmptyBlock', $service->load(array('name' => '/test/blocks/block-2')));
+    }
+}

--- a/tests/WebTest/Admin/Block/PHPCRBlockLoaderTest.php
+++ b/tests/WebTest/Admin/Block/PHPCRBlockLoaderTest.php
@@ -3,13 +3,13 @@
 /*
  * This file is part of the Symfony CMF package.
  *
- * (c) 2011-2015 Symfony CMF
+ * (c) 2011-2016 Symfony CMF
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Cmf\Bundle\BlockBundle\Tests\WebTest\Admin;
+namespace Symfony\Cmf\Bundle\SonataAdminIntegrationBundle\Tests\WebTest\Admin\Block;
 
 use Symfony\Cmf\Bundle\BlockBundle\Block\PhpcrBlockLoader;
 use Symfony\Cmf\Component\Testing\Functional\BaseTestCase;
@@ -20,7 +20,7 @@ class PHPCRBlockLoaderTest extends BaseTestCase
     public function setUp()
     {
         $this->db('PHPCR')->loadFixtures(array(
-            'Symfony\Cmf\Bundle\BlockBundle\Tests\Resources\DataFixtures\Phpcr\LoadBlockData',
+            'Symfony\Cmf\Bundle\SonataAdminIntegrationBundle\Tests\Resources\DataFixtures\Phpcr\LoadBlockData',
         ));
         $this->client = $this->createClient();
     }

--- a/tests/WebTest/Admin/Block/ReferenceBlockAdminTest.php
+++ b/tests/WebTest/Admin/Block/ReferenceBlockAdminTest.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * This file is part of the Symfony CMF package.
+ *
+ * (c) 2011-2015 Symfony CMF
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Cmf\Bundle\BlockBundle\Tests\WebTest\Admin;
+
+/**
+ * @author Nicolas Bastien <nbastien@prestaconcept.net>
+ */
+class ReferenceBlockAdminTest extends AbstractBlockAdminTestCase
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function testBlockList()
+    {
+        $this->makeListAssertions(
+            '/admin/cmf/block/referenceblock/list',
+            array('reference-block-1', 'reference-block-2')
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function testBlockEdit()
+    {
+        $this->makeEditAssertions(
+            '/admin/cmf/block/referenceblock/test/blocks/reference-block-1/edit',
+            array('reference-block-1')
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function testBlockCreate()
+    {
+        $this->makeCreateAssertions(
+            '/admin/cmf/block/referenceblock/create',
+            array(
+                'parentDocument' => '/test/blocks',
+                'name' => 'foo-test-container',
+            )
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function testBlockDelete()
+    {
+        $this->makeDeleteAssertions('/admin/cmf/block/referenceblock/test/blocks/reference-block-1/delete');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function testBlockShow()
+    {
+        $this->makeShowAssertions(
+            '/admin/cmf/block/referenceblock/test/blocks/reference-block-1/show',
+            array('reference-block-1')
+        );
+    }
+}

--- a/tests/WebTest/Admin/Block/ReferenceBlockAdminTest.php
+++ b/tests/WebTest/Admin/Block/ReferenceBlockAdminTest.php
@@ -3,13 +3,13 @@
 /*
  * This file is part of the Symfony CMF package.
  *
- * (c) 2011-2015 Symfony CMF
+ * (c) 2011-2016 Symfony CMF
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Cmf\Bundle\BlockBundle\Tests\WebTest\Admin;
+namespace Symfony\Cmf\Bundle\SonataAdminIntegrationBundle\Tests\WebTest\Admin\Block;
 
 /**
  * @author Nicolas Bastien <nbastien@prestaconcept.net>

--- a/tests/WebTest/Admin/Block/SimpleBlockAdminTest.php
+++ b/tests/WebTest/Admin/Block/SimpleBlockAdminTest.php
@@ -1,0 +1,75 @@
+<?php
+
+/*
+ * This file is part of the Symfony CMF package.
+ *
+ * (c) 2011-2015 Symfony CMF
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Cmf\Bundle\BlockBundle\Tests\WebTest\Admin;
+
+/**
+ * @author David Buchmann <david@liip.ch>
+ */
+class SimpleBlockAdminTest extends AbstractBlockAdminTestCase
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function testBlockList()
+    {
+        $this->makeListAssertions(
+            '/admin/cmf/block/simpleblock/list',
+            array('block-1', 'block-1-title', 'block-2')
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function testBlockEdit()
+    {
+        $this->makeEditAssertions(
+            '/admin/cmf/block/simpleblock/test/blocks/block-1/edit',
+            array('block-1', 'block-1-title')
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function testBlockCreate()
+    {
+        $this->makeCreateAssertions(
+            '/admin/cmf/block/simpleblock/create',
+            array(
+                'parentDocument' => '/test/blocks',
+                'name' => 'foo-test',
+                'title' => 'Foo Test',
+                'body' => 'Block body foo bar.',
+            )
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function testBlockDelete()
+    {
+        $this->makeDeleteAssertions('/admin/cmf/block/simpleblock/test/blocks/block-1/delete');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function testBlockShow()
+    {
+        $this->makeShowAssertions(
+            '/admin/cmf/block/simpleblock/test/blocks/block-1/show',
+            array('block-1')
+        );
+    }
+}

--- a/tests/WebTest/Admin/Block/SimpleBlockAdminTest.php
+++ b/tests/WebTest/Admin/Block/SimpleBlockAdminTest.php
@@ -3,13 +3,13 @@
 /*
  * This file is part of the Symfony CMF package.
  *
- * (c) 2011-2015 Symfony CMF
+ * (c) 2011-2016 Symfony CMF
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Cmf\Bundle\BlockBundle\Tests\WebTest\Admin;
+namespace Symfony\Cmf\Bundle\SonataAdminIntegrationBundle\Tests\WebTest\Admin\Block;
 
 /**
  * @author David Buchmann <david@liip.ch>

--- a/tests/WebTest/Admin/Block/StringBlockAdminTest.php
+++ b/tests/WebTest/Admin/Block/StringBlockAdminTest.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * This file is part of the Symfony CMF package.
+ *
+ * (c) 2011-2015 Symfony CMF
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Cmf\Bundle\BlockBundle\Tests\WebTest\Admin;
+
+/**
+ * @author Nicolas Bastien <nbastien@prestaconcept.net>
+ */
+class StringBlockAdminTest extends AbstractBlockAdminTestCase
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function testBlockList()
+    {
+        $this->makeListAssertions(
+            '/admin/cmf/block/stringblock/list',
+            array('string-block-1', 'string-block-2')
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function testBlockEdit()
+    {
+        $this->makeEditAssertions(
+            '/admin/cmf/block/stringblock/test/blocks/string-block-1/edit',
+            array('string-block-1')
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function testBlockCreate()
+    {
+        $this->makeCreateAssertions(
+            '/admin/cmf/block/stringblock/create',
+            array(
+                'parentDocument' => '/test/blocks',
+                'name' => 'foo-test-container',
+                'body' => 'string-block-1-body',
+            )
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function testBlockDelete()
+    {
+        $this->makeDeleteAssertions('/admin/cmf/block/stringblock/test/blocks/string-block-1/delete');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function testBlockShow()
+    {
+        $this->makeShowAssertions(
+            '/admin/cmf/block/stringblock/test/blocks/string-block-1/show',
+            array('string-block-1')
+        );
+    }
+}

--- a/tests/WebTest/Admin/Block/StringBlockAdminTest.php
+++ b/tests/WebTest/Admin/Block/StringBlockAdminTest.php
@@ -3,13 +3,13 @@
 /*
  * This file is part of the Symfony CMF package.
  *
- * (c) 2011-2015 Symfony CMF
+ * (c) 2011-2016 Symfony CMF
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Cmf\Bundle\BlockBundle\Tests\WebTest\Admin;
+namespace Symfony\Cmf\Bundle\SonataAdminIntegrationBundle\Tests\WebTest\Admin\Block;
 
 /**
  * @author Nicolas Bastien <nbastien@prestaconcept.net>


### PR DESCRIPTION
fix https://github.com/symfony-cmf/block-bundle/issues/257

ToDo:
* [x] Add Admin classes
* [x] Add configuration
* [x] Add Configuration tests
* [x] Add Web tests
* [x] Add dependencies
* [x] tests green
